### PR TITLE
Fix missing equipment for Karzerfeste shrine staff

### DIFF
--- a/maps/karzerfeste/outfits/shrine.dm
+++ b/maps/karzerfeste/outfits/shrine.dm
@@ -6,6 +6,9 @@
 		/obj/item/clothing/suit/robe/sleeved/shrine
 	)
 	backpack_contents = list(
+		/obj/item/rock/flint/striker,
+		/obj/item/bladed/folding/iron,
+		/obj/item/flame/torch,
 		/obj/item/stack/medical/bandage/crafted/five  = 1,
 		/obj/item/stack/medical/ointment/crafted/five = 1,
 		/obj/item/stack/medical/splint/crafted/five   = 1


### PR DESCRIPTION
## Description of changes
Fixes missing equipment. Theoretically we could make it an `additional_backpack_contents` list that adds to the job ones on decl init but this is really just a quick and dirty fix before volatile, the upstream fix for the same issue on Shaded Hills could include that though

## Why and what will this PR improve
Shrine staff start with a torch, striker, and iron knife on Karzerfeste, just like other roles.